### PR TITLE
Refactor Angular docs structure and apply content updates

### DIFF
--- a/_includes/repo_links.html
+++ b/_includes/repo_links.html
@@ -1,8 +1,8 @@
 <div class="repo-links">
   <h3>Technology Categories</h3>
   <ul>
-{% for name, url in site.repository_links %}
-  <li><a href="{{ url | relative_url }}">{{ name | capitalize }}</a></li>
+{% for pair in site.repository_links %}
+  <li><a href="{{ pair[1] | relative_url }}">{{ pair[0] | capitalize }}</a></li>
 {% endfor %}
   </ul>
 </div>

--- a/angular/dynamically_set_page_title.md
+++ b/angular/dynamically_set_page_title.md
@@ -1,3 +1,8 @@
+---
+title: "Dynamically Set Page Title"
+layout: default
+nav_order: 8
+---
 # dynamically-set-page-title-in-angular
 
 ref: https://dev.to/nightwolfdev/dynamically-set-page-title-in-angular-app-35ca

--- a/angular/file_download.md
+++ b/angular/file_download.md
@@ -1,3 +1,8 @@
+---
+title: "File Download"
+layout: default
+nav_order: 9
+---
 # File downloads
 
 ### Service function

--- a/angular/file_upload.md
+++ b/angular/file_upload.md
@@ -1,3 +1,8 @@
+---
+title: "File Upload"
+layout: default
+nav_order: 10
+---
 # Angular File Uploader
 
 

--- a/angular/flask.md
+++ b/angular/flask.md
@@ -1,3 +1,8 @@
+---
+title: "Angular and Flask"
+layout: default
+nav_order: 5
+---
 # Angular and Flask
 
 Great article [Single page applications with Flask and Angular](https://www.xemedo.com/en/single-page-applications-with-flask-and-angular/)
@@ -5,4 +10,3 @@ Great article [Single page applications with Flask and Angular](https://www.xeme
 ## Flask REST API password reset
 
 Some good notes on: [Flask Rest API -Part:5- Password Reset](https://dev.to/paurakhsharma/flask-rest-api-part-5-password-reset-2f2e)
-

--- a/angular/forms.md
+++ b/angular/forms.md
@@ -1,3 +1,8 @@
+---
+title: "Angular Forms"
+layout: default
+nav_order: 11
+---
 ## Angular Forms
 
 ## Theming

--- a/angular/googlemaps.md
+++ b/angular/googlemaps.md
@@ -1,3 +1,8 @@
+---
+title: "Google Maps Integration"
+layout: default
+nav_order: 12
+---
 # GoogleMaps
 
 ## Install dependencies

--- a/angular/http.md
+++ b/angular/http.md
@@ -1,3 +1,8 @@
+---
+title: "Angular HTTP Client"
+layout: default
+nav_order: 13
+---
 # http
 
 ref: [Learn rxjs](https://www.learnrxjs.io/learn-rxjs/operators/error_handling/retrywhen)

--- a/angular/jquery.md
+++ b/angular/jquery.md
@@ -1,3 +1,8 @@
+---
+title: "Using jQuery with Angular"
+layout: default
+nav_order: 14
+---
 More elegant way without using
 
     declare var $: any;

--- a/angular/main.md
+++ b/angular/main.md
@@ -1,3 +1,8 @@
+---
+title: "Angular Core Concepts"
+layout: default
+nav_order: 15
+---
 # angular
 
 * [angular-cli](ng_CLI.md)

--- a/angular/material.md
+++ b/angular/material.md
@@ -1,3 +1,8 @@
+---
+title: "Angular Material"
+layout: default
+nav_order: 6
+---
 # Angular and Material
 
 ## New project with material

--- a/angular/ng-generate.md
+++ b/angular/ng-generate.md
@@ -1,3 +1,8 @@
+---
+title: "ng generate (Angular CLI)"
+layout: default
+nav_order: 16
+---
 # ng generate
 
 ## Modules
@@ -30,6 +35,3 @@ Create User class and service
 
   $ ng generate class shared/user/user
   $ ng generate service shared/user/user
-
-
-

--- a/angular/node_npm.md
+++ b/angular/node_npm.md
@@ -1,3 +1,8 @@
+---
+title: "Node.js and npm"
+layout: default
+nav_order: 17
+---
 # Node & npm
 
 ## NPM Global (user)
@@ -96,4 +101,3 @@ $ npm update
 + @angular/compiler@10.2.5
 + @angular/core@10.2.5
 ```
-

--- a/angular/pwa.md
+++ b/angular/pwa.md
@@ -1,3 +1,8 @@
+---
+title: "Progressive Web Apps (PWA)"
+layout: default
+nav_order: 7
+---
 # Progressive Web App
 
 * [Progressive Web App Checklist](https://developers.google.com/web/progressive-web-apps/checklist)

--- a/angular/styling.md
+++ b/angular/styling.md
@@ -1,3 +1,8 @@
+---
+title: "CSS Styling in Angular"
+layout: default
+nav_order: 18
+---
 # CSS Styling tips
 
 * [A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)

--- a/angular/tools.md
+++ b/angular/tools.md
@@ -1,3 +1,8 @@
+---
+title: "Angular Developer Tools"
+layout: default
+nav_order: 19
+---
 ## DatePicker
 
 Using NgbModule you need to convert initial value


### PR DESCRIPTION
This commit addresses several aspects of the Angular reference documentation:

1.  **Improved Angular Topic Listing**:
    - Modified `angular/index.md` to use correct Jekyll Liquid templating for dynamically generating a sorted list of all Angular topic pages. Pages are sorted by their `nav_order` front matter.

2.  **Updated External Links**:
    - Reviewed and updated external resource links in `angular/index.md`.
    - Replaced an inaccessible link with the official Angular Style Guide (`https://angular.dev/guide/style-guide`).
    - Refreshed link text for another resource to reflect its current content.

3.  **Content Corrections and Modernization**:
    - `angular/angular_and_tailwind.md`: - Standardized Tailwind config filename to `tailwind.config.js`. - Updated the Tailwind Elements (now TW Elements) link to `https://tw-elements.com/` and corrected its plugin import path in `tailwind.config.js`.
    - `angular/authentication.md`:
        - Replaced deprecated RxJS `Observable.throw()` with `throwError()`.
    - `angular/ng_CLI.md`: - Removed an outdated section on CLI version mismatch. - Updated the primary CLI documentation link to `https://angular.dev/cli`. - Corrected an example output for `ng generate module`.

4.  **Fixed Jekyll Build Error**:
    - Corrected a Liquid `for` loop syntax error in `_includes/repo_links.html` which was causing a site build failure. The loop now correctly iterates over dictionary items.

5.  **Standardized Front Matter for Angular Pages**:
    - Added missing front matter (`layout: default`, `title`, and `nav_order`) to 15 Angular content pages. This ensures consistent page rendering, styling, and their inclusion and correct ordering in the main Angular topic list.

These changes improve the structure, accuracy, and maintainability of the Angular documentation section.